### PR TITLE
Binary classification uses binary labels

### DIFF
--- a/simpleml/metrics/classification.py
+++ b/simpleml/metrics/classification.py
@@ -91,18 +91,18 @@ class BinaryClassificationMetric(ClassificationMetric):
         labels = self.model.get_labels(dataset_split=self.dataset_split)
         self.validate_labels(labels)
         return labels
-    
+
     @staticmethod
     def validate_labels(labels):
         invalid = None
         if labels is None:
             invalid = True
         else:
-            invalid = (len(set(labels) - {0,1}) > 0)
+            invalid = (len(set(labels) - {0, 1}) > 0)
 
         if invalid:
             raise MetricError('Attempting to score a binary metric with labels outside of {0,1}')
-    
+
     @property
     def probabilities(self):
         probabilities = super(BinaryClassificationMetric, self).probabilities
@@ -142,7 +142,7 @@ class BinaryClassificationMetric(ClassificationMetric):
         results = []
         for threshold in thresholds:
             predictions = np.where(probabilities >= threshold, 1, 0)
-            tn, fp, fn, tp = confusion_matrix(labels, predictions, labels=[0,1]).ravel()
+            tn, fp, fn, tp = confusion_matrix(labels, predictions, labels=[0, 1]).ravel()
             results.append((threshold, tn, fp, fn, tp))
 
         self._confusion_matrix = pd.DataFrame(results, columns=['threshold', 'tn', 'fp', 'fn', 'tp'])

--- a/simpleml/metrics/classification.py
+++ b/simpleml/metrics/classification.py
@@ -89,7 +89,7 @@ class BinaryClassificationMetric(ClassificationMetric):
     @property
     def labels(self):
         # extends parent label retrieval with a validation step for binary values
-        labels = super(BinaryClassificationMetric, self).labels 
+        labels = super(BinaryClassificationMetric, self).labels
         self.validate_labels(labels)
         return labels
 

--- a/simpleml/metrics/classification.py
+++ b/simpleml/metrics/classification.py
@@ -88,7 +88,8 @@ class ClassificationMetric(Metric):
 class BinaryClassificationMetric(ClassificationMetric):
     @property
     def labels(self):
-        labels = self.model.get_labels(dataset_split=self.dataset_split)
+        # extends parent label retrieval with a validation step for binary values
+        labels = super(BinaryClassificationMetric, self).labels 
         self.validate_labels(labels)
         return labels
 

--- a/simpleml/metrics/classification.py
+++ b/simpleml/metrics/classification.py
@@ -87,6 +87,23 @@ class ClassificationMetric(Metric):
 
 class BinaryClassificationMetric(ClassificationMetric):
     @property
+    def labels(self):
+        labels = self.model.get_labels(dataset_split=self.dataset_split)
+        self.validate_labels(labels)
+        return labels
+    
+    @staticmethod
+    def validate_labels(labels):
+        invalid = None
+        if labels is None:
+            invalid = True
+        else:
+            invalid = (len(set(labels) - {0,1}) > 0)
+
+        if invalid:
+            raise MetricError('Attempting to score a binary metric with labels outside of {0,1}')
+    
+    @property
     def probabilities(self):
         probabilities = super(BinaryClassificationMetric, self).probabilities
         if len(probabilities.shape) > 1 and probabilities.shape[1] > 1:
@@ -125,7 +142,7 @@ class BinaryClassificationMetric(ClassificationMetric):
         results = []
         for threshold in thresholds:
             predictions = np.where(probabilities >= threshold, 1, 0)
-            tn, fp, fn, tp = confusion_matrix(labels, predictions).ravel()
+            tn, fp, fn, tp = confusion_matrix(labels, predictions, labels=[0,1]).ravel()
             results.append((threshold, tn, fp, fn, tp))
 
         self._confusion_matrix = pd.DataFrame(results, columns=['threshold', 'tn', 'fp', 'fn', 'tp'])


### PR DESCRIPTION
Ensure labels for binary classification metrics are in {0,1} so that create_confusion_matrix behaves correctly when it forces predictions to {0,1}. Set labels in confusion_matrix params to ensure raveling of confusion matrix still expands to tn/fp/fn/tp even when confusion_matrix would otherwise produce a 1x1 matrix.